### PR TITLE
Export PATH atload of pyenv plugin

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,6 +10,7 @@
       become: yes
   tasks:
     - name: "Include role zsh"
+      become: yes
       ansible.builtin.import_role:
         name: nekeal.zsh
   vars:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,7 +14,8 @@ platforms:
     image: "nekeal/${MOLECULE_DISTRO:-debian10}-ansible-systemd:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
     pre_build_image: true
 provisioner:

--- a/tasks/install_zsh.yml
+++ b/tasks/install_zsh.yml
@@ -32,6 +32,7 @@
   when: ansible_os_family != "Debian"
 
 - name: Install zsh
+  when: zsh_installed_version_result is failed or zsh_reinstall_from_source
   block:
     - name: Download zsh archive
       ansible.builtin.get_url:
@@ -53,15 +54,13 @@
         creates: "{{ zsh_build_directory }}/config.status"
 
     - name: Build zsh
-      ansible.builtin.make:
+      community.general.make:
         chdir: "{{ zsh_build_directory }}"
 
     - name: Install zsh
-      ansible.builtin.make:
+      community.general.make:
         chdir: "{{ zsh_build_directory }}"
         target: install
         params:
           bindir: "{{ zsh_install_bin_prefix }}"
       become: yes
-
-  when: zsh_installed_version_result is failed or zsh_reinstall_from_source

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,19 +6,19 @@
     - zinit
 
 - name: Install zsh
-  import_tasks: "install_zsh.yml"
+  ansible.builtin.import_tasks: "install_zsh.yml"
   tags:
     - zsh
     - zinit
 
 - name: Configure templates
-  import_tasks: templates.yml
+  ansible.builtin.import_tasks: templates.yml
   tags:
     - zsh
     - zsh-templates
 
 - name: Install zinit
-  import_tasks: zinit.yml
+  ansible.builtin.import_tasks: zinit.yml
   tags:
     - zsh
     - zinit

--- a/templates/zinit-plugins-default.zsh.j2
+++ b/templates/zinit-plugins-default.zsh.j2
@@ -34,7 +34,7 @@ zinit load sparsick/ansible-zsh
 zinit load Tarrasch/zsh-autoenv
 zinit load djui/alias-tips
 zinit ice atload="autoload -U +X bashcompinit && bashcompinit" zinit load macunha1/zsh-terraform
-zinit ice wait=!0 lucid; zinit load mattberther/zsh-pyenv
+zinit ice wait=!0 lucid; zinit ice atload='[[ $VIRTUAL_ENV ]]; export PATH=$VIRTUAL_ENV/bin:$PATH'; zinit load mattberther/zsh-pyenv # it prevents overriding PATH when using virtualenv
 zinit ice as=command from=gh-r sbin=fzf id-as=fzf; zinit load junegunn/fzf
 zinit ice depth"1" multisrc"shell/{completion,key-bindings}.zsh" pick="/dev/null"; zinit load junegunn/fzf
 zinit ice wait=!0 lucid; zinit load lukechilds/zsh-nvm


### PR DESCRIPTION
Sometimes it happens that virtualenv is activated before a  pyenv fully loads. In such a case pyenv overrides `PATH` variable and Python from virtualenv isn't considered by default. 